### PR TITLE
Update FactorioSpeedControl control.lua to allow speed as low as 0.1

### DIFF
--- a/SpeedControl_1.0.21/control.lua
+++ b/SpeedControl_1.0.21/control.lua
@@ -70,7 +70,7 @@ script.on_event(defines.events, function(event)
 end)
 
 function speed(adjust)
-    game.speed = math.clamp(game.speed + adjust, 0.5, 10)
+    game.speed = math.clamp(game.speed + adjust, 0.1, 10)
 
 	for playerIndex, player in pairs(game.players) do
 		if player.gui.top.decrease then


### PR DESCRIPTION
For Pyanodon mod players an end game factory can easily tax computers enough that even a very efficient factory runs below 50% game speed (10% is common by the end), setting a lower speed is important to allow people with slower computers to connect.